### PR TITLE
Create openssf-governing-board.md with initial content

### DIFF
--- a/openssf-governing-board.md
+++ b/openssf-governing-board.md
@@ -1,0 +1,26 @@
+---
+lfx_committee_url: https://projectadmin.lfx.linuxfoundation.org/project/a092M00001Iw46JQAR/collaboration/committees/59c12dc9-7793-4efd-ba4c-0e0eabafca69
+---
+
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
+
+<style>
+.name, .company {
+    font-family: "Red Hat Display", sans-serif !important;
+    font-optical-sizing: auto;
+    font-style: normal;
+    font-weight: 300;
+}
+.company {
+    font-size: smaller;
+}
+.title, .role {
+    display: none !important;
+}
+div.member[style] {
+    order: 0 !important;
+}
+</style>


### PR DESCRIPTION
Add initial content and styles for the OpenSSF governing board render.