### PR TITLE
Have OpenWallet GB render be for a slidedeck

### DIFF
--- a/openwallet-foundation-governing-board.md
+++ b/openwallet-foundation-governing-board.md
@@ -1,4 +1,3 @@
 ---
 lfx_committee_url: https://projectadmin.lfx.linuxfoundation.org/project/a092M00001L18DzQAJ/collaboration/committees/f6282cf6-7e39-4b31-b633-f94c6620146c
-render: newsite
 ---


### PR DESCRIPTION
Remove 'render: newsite' line from the document.

FYI - @estherrgarcia 